### PR TITLE
Tweak module.prop

### DIFF
--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,7 @@
 id=Lawnchair
-name=Lawnchair launcher + icons + feeds + recents
+name=Lawnchair full package
 version=v12-dev59.1
 versionCode=29
 author=Psk.It
-description=Lawnchair full package
+description=Lawnchair launcher + icons + feeds + recents
+minApi=30


### PR DESCRIPTION
Linked to https://github.com/Fox2Code/FoxMagiskModuleManager/issues/87

Lawnchair launcher doesn't support to be a recent provider under API 30

See: https://github.com/LawnchairLauncher/lawnchair/blob/12-dev/lawnchair/AndroidManifest.xml#L104

Also swap description and name, as it is better to have a short name and long description.